### PR TITLE
async.nette.ajax.js: Pass UI and Event

### DIFF
--- a/src/assets/async.nette.ajax.js
+++ b/src/assets/async.nette.ajax.js
@@ -17,7 +17,7 @@
 				$.nette.ajax({
 					url: $this.data('asyncLink') || $this.attr('href'),
 					off: ['history', 'unique']
-				});
+				}, $this, new CustomEvent('asyncLoad'));
 			});
 		}
 	});


### PR DESCRIPTION
some nette.ajax extensions does not check for UI/Event presence and breaks