### PR TITLE
JS asset doesn't work in IE

### DIFF
--- a/src/assets/async.nette.ajax.js
+++ b/src/assets/async.nette.ajax.js
@@ -17,7 +17,7 @@
 				$.nette.ajax({
 					url: $this.data('asyncLink') || $this.attr('href'),
 					off: ['history', 'unique']
-				}, $this, new CustomEvent('asyncLoad'));
+				}, $this, new Event('asyncLoad'));
 			});
 		}
 	});


### PR DESCRIPTION
Issue #8.

In the nette extension JS use `Event` constructor instead of `CustomEvent`. Since there are no custom data passed into the event, behavior should be unchanged, but extension is compatible with IE11.

Alternatively, [`jQuery.Event`](https://api.jquery.com/category/events/event-object/) constructor could be used, which would be compatible with "all" IE (depending on jQuery version).