### PR TITLE
#8 JS asset doesn't work in IE

### DIFF
--- a/src/assets/async.nette.ajax.js
+++ b/src/assets/async.nette.ajax.js
@@ -17,7 +17,7 @@
 				$.nette.ajax({
 					url: $this.data('asyncLink') || $this.attr('href'),
 					off: ['history', 'unique']
-				}, $this, new Event('asyncLoad'));
+				}, $this, $.Event('asyncLoad'));
 			});
 		}
 	});


### PR DESCRIPTION
Turns out that IE doesn't support `Event()` constructor either. Since there is already dependency on jQuery, I suggest using jQuery's `$.Event()` constructor instead.