### PR TITLE
podpora pro nette 3.1 a php 8.3

### DIFF
--- a/.github/workflows/php-package-ci.yml
+++ b/.github/workflows/php-package-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.4, 8.0 ]
+        php: [ 7.4, 8.0, 8.1, 8.2, 8.3 ]
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,13 @@
 	],
 	"require": {
 		"php": "~7.4 | ~8.0",
-		"nette/application": "^2.4"
+		"nette/application": "^2.4 | ^3.0"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "^1.0",
 		"nette/tester": "^2.0",
-		"mockery/mockery": "^1.0"
+		"mockery/mockery": "^1.0",
+		"phpstan/phpstan-nette": "^1.2"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,7 @@ parameters:
 		- phpt
 
 	treatPhpDocTypesAsCertain: false
+
+includes:
+	- vendor/phpstan/phpstan-nette/extension.neon
+	- vendor/phpstan/phpstan-nette/rules.neon

--- a/src/UI/AsyncControlTrait.php
+++ b/src/UI/AsyncControlTrait.php
@@ -43,9 +43,7 @@ trait AsyncControlTrait
 	public function renderAsync(string $linkMessage = NULL, array $linkAttributes = NULL): void
 	{
 		$template = $this->createTemplate();
-		if ($template instanceof Template) {
-			$template->add('link', new AsyncControlLink($linkMessage, $linkAttributes));
-		}
+		$template->link = new AsyncControlLink($linkMessage, $linkAttributes);
 		$template->setFile(__DIR__ . '/templates/asyncLoadLink.latte');
 		$template->render();
 	}

--- a/tests/UI/AsyncControlTest.phpt
+++ b/tests/UI/AsyncControlTest.phpt
@@ -62,13 +62,19 @@ final class AsyncControlTest extends TestCase
 	{
 		$control = Mockery::mock(AsyncControl::class)->makePartial();
 
-		$template = Mockery::mock(Template::class);
-		$template->shouldReceive('add')->once()->with('link', Mockery::type(AsyncControlLink::class));
+		$template = Mockery::mock(Template::class)->makePartial();
+		$template->link = Mockery::type(AsyncControlLink::class);
 		$template->shouldReceive('setFile')->once()->withAnyArgs();
 		$template->shouldReceive('render')->once();
 
 		$templateFactory = Mockery::mock(TemplateFactory::class);
-		$templateFactory->shouldReceive('createTemplate')->once()->with($control)->andReturn($template);
+		$templateFactory
+			->shouldReceive('createTemplate')
+			->once()
+			->withArgs(
+				fn ($recievedControl) => $recievedControl === $control
+			)
+			->andReturn($template);
 
 		$presenter = Mockery::mock(Presenter::class);
 		$presenter->shouldReceive('getTemplateFactory')->once()->andReturn($templateFactory);


### PR DESCRIPTION
Přidává podporu pro nette 3.1 a php 8.3

- instalace `phpstan/phpstan-nette` kvůli odstranění erroru při pracování s `$this->template->link`
- `template` nemá v nette 3.1 již metodu `add`, proto přepsáno nette způsob, vytváření proměnných

